### PR TITLE
ClickHouseVapor fail safely if row count is inconsistent

### DIFF
--- a/Sources/ClickHouseVapor/ClickHouseColumnConvertible.swift
+++ b/Sources/ClickHouseVapor/ClickHouseColumnConvertible.swift
@@ -40,7 +40,7 @@ extension ClickHouseColumnConvertibleTyped {
     
     public func setClickHouseArray(_ data: [ClickHouseDataType]) throws {
         guard let array = data as? [Value] else {
-            throw ClickHouseVaporError.missmatchingDataType(columnName: key)
+            throw ClickHouseVaporError.mismatchingDataType(columnName: key)
         }
         self.wrappedValue = array
     }

--- a/Sources/ClickHouseVapor/ClickHouseVaporError.swift
+++ b/Sources/ClickHouseVapor/ClickHouseVaporError.swift
@@ -6,5 +6,6 @@
 //
 
 public enum ClickHouseVaporError: Error {
-    case missmatchingDataType(columnName: String)
+    case mismatchingDataType(columnName: String)
+    case mismatchingRowCount(count: Int, expected: Int)
 }


### PR DESCRIPTION
IMO an insert should throw if one tries to insert columns with differing amount of rows into a table. 
Currently, per default values are filled with 0 for numerical data types or "" for strings, see: https://clickhouse.tech/docs/en/sql-reference/statements/insert-into/