### PR TITLE
Add support for new types added in ClickHouseNIO 1.4

### DIFF
--- a/Sources/ClickHouseVapor/Application+ClickHouseNIO.swift
+++ b/Sources/ClickHouseVapor/Application+ClickHouseNIO.swift
@@ -10,6 +10,13 @@ import ClickHouseNIO
 
 @_exported import struct NIO.TimeAmount
 
+@_exported import struct ClickHouseNIO.ClickHouseDate
+@_exported import struct ClickHouseNIO.ClickHouseDate32
+@_exported import struct ClickHouseNIO.ClickHouseDateTime
+@_exported import struct ClickHouseNIO.ClickHouseDateTime64
+@_exported import struct ClickHouseNIO.ClickHouseEnum8
+@_exported import struct ClickHouseNIO.ClickHouseEnum16
+
 /// Vapor `Application.ClickHouse` and `Request.ClickHouse` implement this procotol to be used later for queries
 public protocol ClickHouseConnectionProtocol {
     var eventLoop: EventLoop { get }

--- a/Sources/ClickHouseVapor/ClickHouseEngine.swift
+++ b/Sources/ClickHouseVapor/ClickHouseEngine.swift
@@ -117,6 +117,22 @@ extension ClickHouseTypeName {
             return true
         case .nullable(let type):
             return type.supportsLowCardinality
-        }
+        case .array(let type):
+            return type.supportsLowCardinality
+        case .boolean: 
+            return true
+        case .date: 
+            return false
+        case .date32: 
+            return false
+        case .dateTime(_): 
+            return false
+        case .dateTime64(_): 
+            return false
+        case .enum16(_): 
+            return false
+        case .enum8(_): 
+            return false
+}
     }
 }

--- a/Sources/ClickHouseVapor/ClickHouseEngine.swift
+++ b/Sources/ClickHouseVapor/ClickHouseEngine.swift
@@ -118,7 +118,7 @@ extension ClickHouseTypeName {
         case .nullable(let type):
             return type.supportsLowCardinality
         case .array(let type):
-            return type.supportsLowCardinality
+            return false
         case .boolean: 
             return true
         case .date: 

--- a/Sources/ClickHouseVapor/ClickHouseEngine.swift
+++ b/Sources/ClickHouseVapor/ClickHouseEngine.swift
@@ -120,7 +120,7 @@ extension ClickHouseTypeName {
         case .array(let type):
             return false
         case .boolean: 
-            return true
+            return false
         case .date: 
             return false
         case .date32: 

--- a/Sources/ClickHouseVapor/ClickHouseModel.swift
+++ b/Sources/ClickHouseVapor/ClickHouseModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import Vapor
 import ClickHouseNIO
 
+
 public protocol ClickHouseModel: AnyObject {
     static var engine: ClickHouseEngine { get }
     init()

--- a/Tests/ClickHouseVaporTests/ClickHouseVaporTests.swift
+++ b/Tests/ClickHouseVaporTests/ClickHouseVaporTests.swift
@@ -33,6 +33,10 @@ public class TestModel: ClickHouseModel {
     @Field(key: "arr")
     var arr: [ [Int64] ]
 
+    /// Not implemented on test-server
+    // @Field(key: "bol")
+    // var bol: [ Bool ]
+
     @Field(key: "dat")
     var dat: [ClickHouseDate]
 

--- a/Tests/ClickHouseVaporTests/ClickHouseVaporTests.swift
+++ b/Tests/ClickHouseVaporTests/ClickHouseVaporTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import ClickHouseVapor
+import Foundation
 import Vapor
 
 extension Application {
@@ -28,6 +29,33 @@ public class TestModel: ClickHouseModel {
 
     @Field(key: "fixed", isLowCardinality: true, fixedStringLen: 10)
     var fixed: [ String ]
+
+    @Field(key: "dat")
+    var dat: [ClickHouseDate]
+
+
+    /// Not implemented on test-server
+    // @Field(key: "dat32")
+    // var dat32: [ClickHouseDate32] 
+
+    @Field(key: "datt")
+    var datt: [ ClickHouseDateTime ]
+
+    ///TODO: requires a fix in ClickHouseNio    
+    // @Field(key: "dattz", timeZone: "'GMT'")
+    // var dattz: [ ClickHouseDateTime ]
+
+    @Field(key: "datt64", precision: 3)
+    var datt64: [ ClickHouseDateTime64 ]
+    
+    @Field(key: "datt64z", precision: 3,timeZone: "'GMT'")
+    var datt64z: [ ClickHouseDateTime64 ]
+    
+    @Field(key: "en8", mapping: ["a": 0, "b": 1])
+    var en8: [ ClickHouseEnum8 ]
+    
+    @Field(key: "en16", mapping: ["a": 12, "b": 1, "c": 600])
+    var en16: [ ClickHouseEnum16 ]
 
     @Field(key: "temperature")
     var temperature: [Float]
@@ -76,25 +104,44 @@ final class ClickHouseVaporTests: XCTestCase {
 
         model.id = [ "x010", "ax51", "cd22" ]
         model.fixed = [ "", "123456", "12345678901234" ]
+        model.dat = [.clickhouseDefault, .clickhouseDefault, .clickhouseDefault]
+        model.datt = [.clickhouseDefault, .clickhouseDefault, .clickhouseDefault]
+        model.datt64 = [.clickhouseDefault, .clickhouseDefault, .clickhouseDefault]
+        model.datt64z = [.clickhouseDefault, .clickhouseDefault, .clickhouseDefault]
+        model.en8 = [.init(word: "a"), .init(word: "b"), .init(word: "a")]
+        model.en16 = [.init(word: "a"), .init(word: "b"), .init(word: "c")]
         model.timestamp = [ 100, 200, 300 ]
         model.temperature = [ 11.1, 10.4, 8.9 ]
         
         let createQuery = TestModel.engine.createTableQuery(columns: model.properties)
-        XCTAssertEqual(createQuery, """
-            CREATE TABLE IF NOT EXISTS `test`  (timestamp Int64,stationID LowCardinality(String),fixed LowCardinality(FixedString(10)),temperature Float32)
+        XCTAssertEqual(createQuery
+            .replacingOccurrences(of: "Enum8('b'=1,'a'=0)", with: "Enum8('a'=0,'b'=1)")
+            .replacingOccurrences(of: "Enum16('b'=1,'a'=12,'c'=600)", with: "Enum16('a'=12,'b'=1,'c'=600)")
+            .replacingOccurrences(of: "Enum16('b'=1,'c'=600,'a'=12)", with: "Enum16('a'=12,'b'=1,'c'=600)")
+            .replacingOccurrences(of: "Enum16('a'=12,'c'=600,'b'=1)", with: "Enum16('a'=12,'b'=1,'c'=600)")
+            .replacingOccurrences(of: "Enum16('c'=600,'b'=1,'a'=12)", with: "Enum16('a'=12,'b'=1,'c'=600)")
+            .replacingOccurrences(of: "Enum16('c'=600,'a'=12,'b'=1)", with: "Enum16('a'=12,'b'=1,'c'=600)"),
+            """
+            CREATE TABLE IF NOT EXISTS `test`  (timestamp Int64,stationID LowCardinality(String),fixed LowCardinality(FixedString(10)),dat Date,datt DateTime,datt64 DateTime64(3),datt64z DateTime64(3, 'GMT'),en8 Enum8('a'=0,'b'=1),en16 Enum16('a'=12,'b'=1,'c'=600),temperature Float32)
             ENGINE = ReplacingMergeTree()
             PRIMARY KEY (timestamp,stationID) PARTITION BY (toYYYYMM(toDateTime(timestamp))) ORDER BY (timestamp,stationID)
             """)
-
         try! TestModel.createTable(on: app.clickHouse).wait()
         try! model.insert(on: app.clickHouse).wait()
-
         let model2 = try! TestModel.select(on: app.clickHouse).wait()
 
         XCTAssertEqual(model.temperature, model2.temperature)
         XCTAssertEqual(model.id, model2.id)
         XCTAssertEqual(["", "123456", "1234567890"], model2.fixed)
         XCTAssertEqual(model.timestamp, model2.timestamp)
+        XCTAssertEqual(model.dat.map { $0.date}, [Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0)])
+        XCTAssertEqual(model2.dat.map { $0.date}, [Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0)])
+        XCTAssertEqual(model.datt.map { $0.date}, [Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0)])
+        XCTAssertEqual(model2.datt.map { $0.date}, [Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0), Date(timeIntervalSince1970: 0.0)])
+        XCTAssertEqual(model.en8.map { $0.word}, ["a", "b", "a"])
+        XCTAssertEqual(model2.en8.map { $0.word}, ["a", "b", "a"])
+        XCTAssertEqual(model.en16.map { $0.word}, ["a", "b", "c"])
+        XCTAssertEqual(model2.en16.map { $0.word}, ["a", "b", "c"])
 
         let filtered = try! TestModel.select(
             on: app.clickHouse,


### PR DESCRIPTION
Tests for Boolean and Date32 Types are not implemented as the server for the tests doen't implement them correctly (or at all for Date32).
There is an error with DateTime with TimeZone fixed in https://github.com/patrick-zippenfenig/ClickHouseNIO/pull/9 .